### PR TITLE
style: :lipstick: Add padding and scope color

### DIFF
--- a/src/components/CircularProgress/CircularProgress.tsx
+++ b/src/components/CircularProgress/CircularProgress.tsx
@@ -1,11 +1,11 @@
 import styles from './CircularProgress.module.scss';
 
-type CircularProgressProps = {
+interface CircularProgressProps {
   size?: number;
   color?: string;
   backgroundColor?: string;
   thickness?: number;
-};
+}
 
 export const CircularProgress = ({
   size = 20,

--- a/src/components/inputs/Checkbox/Checkbox.module.scss
+++ b/src/components/inputs/Checkbox/Checkbox.module.scss
@@ -32,12 +32,12 @@
   align-items: center;
   gap: 0.571rem;
   font-size: 1rem;
-  color: var(--text-color);
   forced-color-adjust: none;
 
   .checkbox {
     width: 1.1rem;
     height: 1.1rem;
+    padding: 0.1rem;
     border: 1px solid var(--border-color);
     border-radius: 4px;
     transition: all 200ms;
@@ -45,11 +45,12 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
+    color: var(--text-color);
   }
 
   svg {
-    width: 1.1rem;
-    height: 1.1rem;
+    width: 1rem;
+    height: 1rem;
     fill: none;
     stroke: var(--checkmark-color);
     stroke-width: 3px;
@@ -125,5 +126,9 @@
 
   &:hover:not([data-disabled]) .checkbox {
     border-color: var(--border-color-pressed);
+  }
+
+  span {
+    color: black;
   }
 }

--- a/src/components/inputs/Checkbox/Checkbox.stories.tsx
+++ b/src/components/inputs/Checkbox/Checkbox.stories.tsx
@@ -88,3 +88,15 @@ export const SecondaryIndeterminate: StoryObj<typeof Checkbox> = {
     isIndeterminate: true
   }
 };
+
+export const Label: StoryObj<typeof Checkbox> = {
+  render: (args) => (
+    <>
+      <Checkbox {...args}>Some label</Checkbox>
+      <Checkbox {...args}>
+        <span style={{ color: 'pink' }}>Some pink label</span>
+      </Checkbox>
+    </>
+  ),
+  args: Base.args
+};


### PR DESCRIPTION
Petite PR pour principalement scoper la couleur de la checkbox, le texte était en vert par défaut sinon. Au passage j’ai remis un tout petit peu de padding sur le SVG, il me semble que ça rend un peu mieux.