### PR TITLE
refactor(icons): :recycle: Add a script to type available icon names

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "npm run prettier:fix && npm run lint:fix",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "vitest --project=storybook"
+    "test": "vitest --project=storybook",
+    "generate:icon-types": "node scripts/generate-icon-types.js"
   },
   "dependencies": {
     "@internationalized/date": "^3.8.1",

--- a/scripts/generate-icon-types.js
+++ b/scripts/generate-icon-types.js
@@ -1,0 +1,19 @@
+// scripts/generate-icon-types.js
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const iconsDir = path.join(__dirname, '../src/components/CustomIcon/icons');
+const outputFile = path.join(__dirname, '../src/components/CustomIcon/icon-names.generated.ts');
+
+const files = fs.readdirSync(iconsDir)
+  .filter(f => f.endsWith('.svg'))
+  .map(f => f.replace(/\.svg$/, ''));
+
+const typeDef = `// This file is auto-generated. Do not edit manually.\nexport type IconName = ${files.map(f => `'${f}'`).join(' | ')};\nexport const availableIconNames = [${files.map(f => `'${f}'`).join(', ')}] as const;\n`;
+
+fs.writeFileSync(outputFile, typeDef);
+console.log(`Generated icon types for ${files.length} icons.`);

--- a/src/components/CustomIcon/CustomIcon.tsx
+++ b/src/components/CustomIcon/CustomIcon.tsx
@@ -1,5 +1,6 @@
 import { useMemo, type SVGProps } from 'react';
-import { getSVGIconsAsComponents, type IconName } from './utils';
+import type { IconName } from './icon-names.generated';
+import { getSVGIconsAsComponents } from './utils';
 
 interface CustomIconProps {
   className?: string;

--- a/src/components/CustomIcon/CustomIconAllPreview.stories.tsx
+++ b/src/components/CustomIcon/CustomIconAllPreview.stories.tsx
@@ -1,9 +1,7 @@
 import { CustomIcon } from './CustomIcon';
-import { getSVGIconsAsComponents } from './utils';
+import { availableIconNames } from './icon-names.generated';
 
-const icons = getSVGIconsAsComponents();
-
-export const AllIcons = ({ className, size = 24, color = '#000' }) => (
+export const AllIcons = ({ className = '', size = 24, color = '#000' }) => (
   <div
     style={{
       maxHeight: '40vh',
@@ -14,7 +12,7 @@ export const AllIcons = ({ className, size = 24, color = '#000' }) => (
       justifyItems: 'center',
       alignItems: 'center'
     }}>
-    {Object.keys(icons).map((name) => (
+    {availableIconNames.map((name) => (
       <div
         key={name}
         style={{

--- a/src/components/CustomIcon/icon-names.generated.ts
+++ b/src/components/CustomIcon/icon-names.generated.ts
@@ -1,0 +1,3 @@
+// This file is auto-generated. Do not edit manually.
+export type IconName = 'add' | 'addChat';
+export const availableIconNames = ['add', 'addChat'] as const;

--- a/src/components/CustomIcon/utils.ts
+++ b/src/components/CustomIcon/utils.ts
@@ -6,11 +6,6 @@ const iconModuleContext = import.meta.glob('./icons/*.svg', {
   eager: true
 }) as Record<string, { default: React.ComponentType }>;
 
-// Create a union type of literal string values
-// We need to manually define this for now since TypeScript can't infer it dynamically
-// This will need to be updated when new icons are added
-export type IconName = 'add' | 'addChat';
-
 export const getSVGIconsAsComponents = () => {
   const processedIcons = Object.keys(iconModuleContext).reduce<Record<string, React.ComponentType>>(
     (acc, path) => {
@@ -23,8 +18,3 @@ export const getSVGIconsAsComponents = () => {
 
   return processedIcons;
 };
-
-// Extract icon names without extensions
-export const availableIconNames = Object.keys(iconModuleContext).map((path) =>
-  path.replace('./icons/', '').replace('.svg', '')
-);


### PR DESCRIPTION
Petit script qui permet de générer un type et une constante pour la liste de icones. La liste était possible au runtime, mais pas le type. Faut juste penser à le faire tourner quand on ajoute une icone…