### PR TITLE
feat: :sparkles: add draft on blur with validation

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.{js,jsx,ts,tsx}": ["eslint --max-warnings 0", "prettier --write"],
+  "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
   "*.{json,css,scss,md}": ["prettier --write"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-      "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.3.tgz",
+      "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -129,10 +129,10 @@
         "@babel/generator": "^7.27.3",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.4",
-        "@babel/parser": "^7.27.4",
+        "@babel/helpers": "^7.27.3",
+        "@babel/parser": "^7.27.3",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.27.4",
+        "@babel/traverse": "^7.27.3",
         "@babel/types": "^7.27.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.4.tgz",
-      "integrity": "sha512-Y+bO6U+I7ZKaM5G5rDUZiYfUvQPUibYmAFe7EnKdnKBbVXDZxvp+MWOH5gYciY0EPk4EScsuFMQBbEfpdRKSCQ==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.3.tgz",
+      "integrity": "sha512-h/eKy9agOya1IGuLaZ9tEUgz+uIRXcbtOhRtUyyMf8JFmn1iT13vnl/IGVWSkdOCG/pC57U4S1jnAabAavTMwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.4.tgz",
-      "integrity": "sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
+      "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
-      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
+      "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -361,15 +361,15 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
+      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.4",
+        "@babel/parser": "^7.27.3",
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
@@ -1745,9 +1745,9 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
-      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4766,9 +4766,9 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.79.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.79.0.tgz",
-      "integrity": "sha512-YVRWxjxsWycWChjKxvaIAPdNC5LX0zpiHoNyTB8teDZpQstM1b7mCuAp3x60cjX1MhLoO3vbaeY29EKst4D4ug==",
+      "version": "5.77.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.77.2.tgz",
+      "integrity": "sha512-TxB9boB0dmTJByAfh36kbhvohNHZiPJe+m+PCnbnfL+gdDHJbp174S6BwbU2dHx980njeAKFmWz8tgHNKG3itw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5259,9 +5259,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.7.8.tgz",
-      "integrity": "sha512-rsRK8T7yxraNRDmpFLZCWqpea6OlXPNRRCjWMx24O1V86KFol7u2gj9zJCv6zB1oJjtnzWceuqdnCgOipFcJPA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.7.3.tgz",
+      "integrity": "sha512-ND4wYfTQI6Cnq6+JvlebtJvGMzHmV4zXLKljAredGv4NwS1SWKdTURH64M9Yw3qZRmDqbSGn90e6axa2jVd32w==",
       "cpu": [
         "arm64"
       ],
@@ -5273,9 +5273,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.7.8.tgz",
-      "integrity": "sha512-16yEMWa+Olqkk8Kl6Bu0ltT5OgEedkSAsxcz1B3yEctrDYp3EMBu/5PPAGhWVGnwhtf3hNe3y15gfYBAjOv5tQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.7.3.tgz",
+      "integrity": "sha512-zrRoLxQ1CGg4kvuDLU9ehCRGFd8TTVdh5G7NRMwt5r/vr5/QPvI2KNM1rBnMQ/p+9KBewlFcT7tMXEMe5ywLwg==",
       "cpu": [
         "x64"
       ],
@@ -5287,9 +5287,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.7.8.tgz",
-      "integrity": "sha512-ST4uqF6FmdZQgv+Q73FU1uHzppeT4mhX3IIEmHlLObrv5Ep50olWRz0iQ4PWovadjHMTAmpuJAGaAuCZYb7UAQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.7.3.tgz",
+      "integrity": "sha512-RM5oviK7F92HZuArZocCl4PQHaaXkS3ofZyHer7kkS2VNRSLpOD6DKioWaGdzrV/LE3AwQf6W7y7awQ4OiqMfw==",
       "cpu": [
         "x64"
       ],
@@ -5301,9 +5301,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.7.8.tgz",
-      "integrity": "sha512-Z/A/4Rm2VWku2g25C3tVb986fY6unx5jaaCFpx1pbAj0OKkyuJ5wcQLHvNbIcJ9qhiYwXfrkB7JNlxrAbg7YFg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.7.3.tgz",
+      "integrity": "sha512-5N8ntE4dsZJXiiLqnefd4/dQvMKLs7iqcCDB/k0i2KHBQkIY9u6lsS9dI5kIgTMFV2g5lVAOSDm2HyAbdpF/oQ==",
       "cpu": [
         "arm"
       ],
@@ -5315,9 +5315,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.7.8.tgz",
-      "integrity": "sha512-HN0p7o38qKmDo3bZUiQa6gP7Qhf0sKgJZtRfSHi6JL2Gi4NaUVF0EO1sQ1RHbeQ4VvfjUGMh3QE5dxEh06BgQQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.7.3.tgz",
+      "integrity": "sha512-w4FhO7HDQLhWAwS5tLhxzQtCbMpeI49S1J6cvBttnpirZd9pViNvQPGXXvLEtoKLbHz/QztvZqU1caqZGzzgQw==",
       "cpu": [
         "arm"
       ],
@@ -5329,9 +5329,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.7.8.tgz",
-      "integrity": "sha512-HsoVqDBt9G69AN0KWeDNJW+7i8KFlwxrbbnJffgTGpiZd6Jw+Q95sqkXp8y458KhKduKLmXfVZGnKBTNxAgPjw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.7.3.tgz",
+      "integrity": "sha512-RJldrMcrJn2p44Uxz8CuspHCdafVZOAxfUv3yP9AWX7Q3F3ahXBXoNsrORtzsS+0ZMGN9pyz3qs8ntCa4j3Img==",
       "cpu": [
         "arm64"
       ],
@@ -5343,9 +5343,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.7.8.tgz",
-      "integrity": "sha512-VfR2yTDUbUvn+e/Aw22CC9fQg9zdShHAfwWctNBdOk7w9CHWl2OtYlcMvjzMAns8QxoHQoqn3/CEnZ4Ts7hfrA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.7.3.tgz",
+      "integrity": "sha512-irbhzOq9JLvp21rxmHGGs9HuDczZbquy6XLKPI4n3Tw2nVG5dFg63cVR4AeqOG1k1pKFEIdMivMAz9wx7xwXZA==",
       "cpu": [
         "arm64"
       ],
@@ -5357,9 +5357,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.7.8.tgz",
-      "integrity": "sha512-xUauVQNz4uDgs4UJJiUAwMe3N0PA0wvtImh7V0IFu++UKZJhssXbKHBRR4ecUJpUHCX2bc4Wc8sGsB6P+7BANg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.7.3.tgz",
+      "integrity": "sha512-hVGQaBQ/jwqi2FeWFTlFCmPMMO9TZ54uisgvYOwTyhXm70JnhDrBlaNJVQrgMYyCVmGGu+IlndCYcLLiYerWnQ==",
       "cpu": [
         "ppc64"
       ],
@@ -5371,9 +5371,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.7.8.tgz",
-      "integrity": "sha512-GqyIB+CuSHGhhc8ph5RrurtNetYJjb6SctSHafqmdGcRuGi6uyTMR8l18hMEhZFsXdFMc/MpInPLvmNV22xn+A==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.7.3.tgz",
+      "integrity": "sha512-FjGB+J+tNyKR1h6gm1+wGzp2EdDqXBOS33e2c7Iz6F6cIJxuGrbhw4F1Hr/HmICE3JLp8ODNi+h+1eK+5D8PCA==",
       "cpu": [
         "riscv64"
       ],
@@ -5385,9 +5385,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.7.8.tgz",
-      "integrity": "sha512-eEU3rWIFRv60xaAbtsgwHNWRZGD7cqkpCvNtio/f1TjEE3HfKLzPNB24fA9X/8ZXQrGldE65b7UKK3PmO4eWIQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.7.3.tgz",
+      "integrity": "sha512-ZiPGSYaHXC49MBSQnW55SAAqw46QUL4Q6GtPtp/3iSEf4KLr0Wz1wmp0y1m9126sO5SMIhV7vzgOe9F5sBw1Lg==",
       "cpu": [
         "riscv64"
       ],
@@ -5399,9 +5399,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.7.8.tgz",
-      "integrity": "sha512-GVLI0f4I4TlLqEUoOFvTWedLsJEdvsD0+sxhdvQ5s+N+m2DSynTs8h9jxR0qQbKlpHWpc2Ortz3z48NHRT4l+w==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.7.3.tgz",
+      "integrity": "sha512-GduxPPeL5O/lP+AOSiNYh8jZTllsJ0xbq9g6GKjrhtx56MO0EvqPmodrZK29Dl4Oa55s5c/jymObsYe2MlDTWw==",
       "cpu": [
         "s390x"
       ],
@@ -5413,9 +5413,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.8.tgz",
-      "integrity": "sha512-GX1pZ/4ncUreB0Rlp1l7bhKAZ8ZmvDIgXdeb5V2iK0eRRF332+6gRfR/r5LK88xfbtOpsmRHU6mQ4N8ZnwvGEA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.3.tgz",
+      "integrity": "sha512-U+ZsvSj41FU5yZ8smcW/oyygRsjOEqhPsMdsL3E6TfLFE1wDoLKgt2SL4GY33Sy+o3kigOEpYbsFy3CUXrYmsg==",
       "cpu": [
         "x64"
       ],
@@ -5427,9 +5427,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.8.tgz",
-      "integrity": "sha512-n1N84MnsvDupzVuYqJGj+2pb9s8BI1A5RgXHvtVFHedGZVBCFjDpQVRlmsFMt6xZiKwDPaqsM16O/1isCUGt7w==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.3.tgz",
+      "integrity": "sha512-ESJHg0tdk13rXMtMjC8wveCrBBX0shwZjpJT9mHkOocdsCoQWY6wD2jRDOqUxnMfrF0OQ2bqZQNoIWqMKyZsDw==",
       "cpu": [
         "x64"
       ],
@@ -5441,9 +5441,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.7.8.tgz",
-      "integrity": "sha512-x94WnaU5g+pCPDVedfnXzoG6lCOF2xFGebNwhtbJCWfceE94Zj8aysSxdxotlrZrxnz5D3ijtyFUYtpz04n39Q==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.7.3.tgz",
+      "integrity": "sha512-rseJbVdntjdI6gj7c8BnBJKa38c3Tv1XmLJ+Hu9DrGOLP5MfmqjdiIRjPuDWt3xOdWzPRnME6OOI/tuAcC0Q+A==",
       "cpu": [
         "wasm32"
       ],
@@ -5458,9 +5458,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.7.8.tgz",
-      "integrity": "sha512-vst2u8EJZ5L6jhJ6iLis3w9rg16aYqRxQuBAMYQRVrPMI43693hLP7DuqyOBRKgsQXy9/jgh204k0ViHkqQgdg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.7.3.tgz",
+      "integrity": "sha512-H+7T2Kfvj7xwiWkloqKWQeBmPcilUIv/FcC6dIvex3rzS9KdLTyF1iLygI9b7jfS8V5mpQ3V6FL91XyCPNufTA==",
       "cpu": [
         "arm64"
       ],
@@ -5472,9 +5472,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.7.8.tgz",
-      "integrity": "sha512-yb3LZOLMFqnA+/ShlE1E5bpYPGDsA590VHHJPB+efnyowT776GJXBoh82em6O9WmYBUq57YblGTcMYAFBm72HA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.7.3.tgz",
+      "integrity": "sha512-Yu3fhFh8vJzzKMkFu+At4rWgbc7BBBqjRz6TAscXYvpSwhGyhHP7AXv6jDT+thZYZHXFlC8NK7RAXgssS/m/Zg==",
       "cpu": [
         "ia32"
       ],
@@ -5486,9 +5486,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.7.8.tgz",
-      "integrity": "sha512-hHKFx+opG5BA3/owMXon8ypwSotBGTdblG6oda/iOu9+OEYnk0cxD2uIcGyGT8jCK578kV+xMrNxqbn8Zjlpgw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.7.3.tgz",
+      "integrity": "sha512-G3aLTm98U9LUGMxVwedEaqWSYID78u1Bxvi5w72GdDpb1DD9pVXc5fRdqzDCApQ657mnEbLZ5YzCoe3zKH8NVQ==",
       "cpu": [
         "x64"
       ],
@@ -5988,9 +5988,9 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -6433,9 +6433,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.24.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
       "dev": true,
       "funding": [
         {
@@ -6584,9 +6584,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "dev": true,
       "funding": [
         {
@@ -7572,9 +7572,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
-      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
+      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -7693,9 +7693,9 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.2.tgz",
-      "integrity": "sha512-GdSOy0PwLYpQCrmnEQujvA+X0NKrdnVCICEbZq1zlmjjD12NHOHCN9MYyrGFR9ydCs4wJwHEV9tts44ajSlGeA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.1.tgz",
+      "integrity": "sha512-KHQnjMAn/Hbs1AcMs2YfJTeNoWsaOoMRvJUKr77Y2dv7jNOaT8/IJYlvfN/ZIwTxUsv2B6amwv7u9bt2Vl9lZg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7865,9 +7865,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
-      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
+      "integrity": "sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8871,9 +8871,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10838,9 +10838,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "dev": true,
       "funding": [
         {
@@ -11765,9 +11765,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.89.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.1.tgz",
-      "integrity": "sha512-eMLLkl+qz7tx/0cJ9wI+w09GQ2zodTkcE/aVfywwdlRcI3EO19xGnbmJwg/JMIm+5MxVJ6outddLZ4Von4E++Q==",
+      "version": "1.89.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.0.tgz",
+      "integrity": "sha512-ld+kQU8YTdGNjOLfRWBzewJpU5cwEv/h5yyqlSeJcj6Yh8U4TDA9UA5FPicqDz/xgRPWRSYIQNiFks21TbA9KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12531,9 +12531,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
-      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12841,9 +12841,9 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.8.tgz",
-      "integrity": "sha512-2zsXwyOXmCX9nGz4vhtZRYhe30V78heAv+KDc21A/KMdovGHbZcixeD5JHEF0DrFXzdytwuzYclcPbvp8A3Jlw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.3.tgz",
+      "integrity": "sha512-AVTaGmPRRPefNaP2egU/QAi/kl29H9mwl6pYTS6EmUHn8+0K2uYQOgIiNBbkv6zviUHCJSYgXin03etx1K2htw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -12854,23 +12854,23 @@
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-darwin-arm64": "1.7.8",
-        "@unrs/resolver-binding-darwin-x64": "1.7.8",
-        "@unrs/resolver-binding-freebsd-x64": "1.7.8",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.8",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.8",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.7.8",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.7.8",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.8",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.8",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.7.8",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.7.8",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.7.8",
-        "@unrs/resolver-binding-linux-x64-musl": "1.7.8",
-        "@unrs/resolver-binding-wasm32-wasi": "1.7.8",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.7.8",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.7.8",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.7.8"
+        "@unrs/resolver-binding-darwin-arm64": "1.7.3",
+        "@unrs/resolver-binding-darwin-x64": "1.7.3",
+        "@unrs/resolver-binding-freebsd-x64": "1.7.3",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.3",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.3",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.7.3",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.7.3",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.3",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.3",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.7.3",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.7.3",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.7.3",
+        "@unrs/resolver-binding-linux-x64-musl": "1.7.3",
+        "@unrs/resolver-binding-wasm32-wasi": "1.7.3",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.7.3",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.7.3",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.7.3"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,0 +1,80 @@
+import {
+  createContext,
+  type FormEvent,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useMemo,
+  useRef
+} from 'react';
+import { Button, Form as ReactAriaForm, type FormProps } from 'react-aria-components';
+
+export const LiveFormContext = createContext<{
+  saveDraft: () => void;
+}>({
+  saveDraft: () => undefined
+});
+
+function LiveForm({
+  draftRef,
+  children
+}: {
+  draftRef: RefObject<HTMLButtonElement | null>;
+  children: ReactNode;
+}) {
+  const saveDraft = useCallback(() => {
+    if (!draftRef.current) return;
+    draftRef.current.click();
+  }, [draftRef]);
+
+  const context = useMemo(
+    () => ({
+      saveDraft
+    }),
+    [saveDraft]
+  );
+
+  return <LiveFormContext.Provider value={context}>{children}</LiveFormContext.Provider>;
+}
+
+const isDraft = (event: React.FormEvent<HTMLFormElement>) => {
+  return event?.nativeEvent?.submitter?.name === 'draft';
+};
+
+export function Form({
+  children,
+  onSubmit,
+  ...props
+}: FormProps & { children: ReactNode; onSubmit: (data: Record<string, unknown>) => void }) {
+  const draftRef = useRef<HTMLButtonElement>(null);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const data = {
+      // simple mapping for example purposes see fieald array story for a more realistic one
+      values: Object.fromEntries(formData.entries()),
+      draft: isDraft(event)
+    };
+
+    // Use the data object as needed (replace with your logic)
+    onSubmit(data);
+  }
+
+  /* eslint-disable */
+  return (
+    <ReactAriaForm {...props} onSubmit={handleSubmit}>
+      <LiveForm draftRef={draftRef}>
+        {children}
+        <Button type="submit" name="draft" formNoValidate ref={draftRef}>
+          Save Draft
+        </Button>
+        <Button type="submit" name="commit">
+          Submit changes
+        </Button>
+      </LiveForm>
+    </ReactAriaForm>
+  );
+}
+/* eslint-enable */

--- a/src/components/inputs/Text/Text.stories.tsx
+++ b/src/components/inputs/Text/Text.stories.tsx
@@ -1,8 +1,8 @@
 import type { StoryObj } from '@storybook/react';
-import { userEvent, within, expect } from '@storybook/test';
-import { type FocusEvent } from 'react';
+import { expect, userEvent, within } from '@storybook/test';
+import { useState, type FocusEvent } from 'react';
+import { Form } from '../../Form/Form';
 import { TextInput } from './Text';
-
 export default {
   title: 'Inputs/TextInput',
   component: TextInput
@@ -65,5 +65,38 @@ export const CustomValidation: StoryObj<typeof TextInput> = {
     await user.type(canvas.getByRole('textbox'), '42');
     await user.tab();
     expect(canvas.queryByText('not the answer')).not.toBeInTheDocument();
+  }
+};
+
+export const AutoSaveForm: StoryObj<typeof TextInput> = {
+  render: () => {
+    const [submittedData, setSubmittedData] = useState<string | null>(null);
+    return (
+      <div style={{ maxWidth: '600px', padding: '20px' }}>
+        <h3>Auto-Save Form</h3>
+        <Form
+          onSubmit={(data) => {
+            setSubmittedData(JSON.stringify(data, null, 2));
+          }}>
+          <TextInput label="First Name" name="first" isRequired />
+          <TextInput label="Last Name" name="second" />
+          <TextInput label="Email" name="email" type="email" isRequired />
+          <TextInput label="Phone Number" name="phone" />
+        </Form>
+        <div
+          style={{
+            marginTop: 16,
+            padding: 12,
+            background: '#f6f8fa',
+            border: '1px solid #d0d7de',
+            borderRadius: 4,
+            fontFamily: 'monospace',
+            fontSize: 14
+          }}>
+          <strong>Data sent to server:</strong>
+          <pre style={{ margin: 0 }}>{submittedData || '—'}</pre>
+        </div>
+      </div>
+    );
   }
 };

--- a/src/components/inputs/Text/Text.tsx
+++ b/src/components/inputs/Text/Text.tsx
@@ -1,5 +1,8 @@
 import classNames from 'classnames';
+import { useContext } from 'react';
 import { FieldError, Input, TextArea, TextField, type TextFieldProps } from 'react-aria-components';
+
+import { LiveFormContext } from '@src/components/Form/Form';
 
 import { Label } from '../Label';
 
@@ -8,18 +11,21 @@ import styles from './Text.module.scss';
 export function TextInput({
   label,
   multiline = false,
+  name,
   ...textFieldProps
 }: {
   label: string;
   multiline?: boolean;
+  name: string;
 } & TextFieldProps) {
   const Cmp = multiline ? TextArea : Input;
   const { isRequired, className } = textFieldProps;
+  const { saveDraft } = useContext(LiveFormContext);
 
   return (
-    <TextField {...textFieldProps} className={classNames(styles.field, className)}>
+    <TextField {...textFieldProps} name={name} className={classNames(styles.field, className)}>
       <Label isRequired={isRequired}>{label}</Label>
-      <Cmp />
+      <Cmp onBlur={saveDraft} />
       <FieldError className={styles.error} />
     </TextField>
   );


### PR DESCRIPTION
Après pas mal d'essais avec des contexts long comme le bras… en fait on s'en sort avec presque tout en natif en fait, pour peu d'avoir deux boutons de submit. On peut cacher celui du draft si besoin.

## Version actuelle
* Field required: pas d'erreur si pas touched/dirty (e.g. pas de valeur entrée puis effacée, erreur). Erreur au blur si on a supprimé une valeur.
* Field ave validation, erreur au blur.
* Submit au blur sans validation (on enregistre même les erreurs).
* Submit final avec validation qui highlight les erreurs.

Les submits ne sont pas désactivés car c'est en fait un mauvais pattern: si c'est désactivé il faut que les fields required vides soit explicitement en erreur. C'est pas fou non plus niveau accessibilité.

Le mapping des data est vraiment basique tout comme le `draft: true` c'est pour donner un exemple.

## Testé puis retiré (mais on peut le mettre)
* Track des field touched (mais en fait le natif le fait bien)
* Track des fields en erreur (si on veut les ajouter en clé aux data draft par exemple)
* lire les values depuis useContext(FormContext). 

## À tester
* Laisser le premier champs vide, remplir les autres. Le remplir, blur, le vider reblur -> erreur.
* Mettre un mail invalid, blur -> erreur.  Supprimer l'erreur, blur -> plus d'erreur.
* Tenter le submit final avec des erreurs.